### PR TITLE
Tweak copy in message shown when first exporting assets

### DIFF
--- a/src/plugin.js
+++ b/src/plugin.js
@@ -402,7 +402,7 @@ var disableBackgroundPlugin = function(){
 var exportAndCompress = function(context){
   var potentialExports = context.document.allExportableLayers()
   if (potentialExports.count() > 0) {
-    showMessage('Exporting compressed assets. This is going to take a bit…')
+    showMessage('Exporting compressed assets. This may take a while…')
     enableBackgroundPlugin()
     var exportFolder = openFileDialog()
     if (exportFolder) {


### PR DESCRIPTION
Standardises the copy a shown in the initial export alert.

I will file separate issues for further suggestions regarding these alerts.